### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rabbitmq.jms</groupId>

--- a/resources/requirements.xml
+++ b/resources/requirements.xml
@@ -179,11 +179,11 @@
   </reference>
 
   <reference referenceId="url.message.bytes">
-    <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html</url>
+    <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html</url>
   </reference>
 
   <reference referenceId="url.message.stream">
-    <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html</url>
+    <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html</url>
   </reference>
 
   <requirement requirementId="selector.null">
@@ -898,7 +898,7 @@
       CLIENT_ACKWNOWLEDGE etc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/faq.html#msg_ack_close</url>
+      <url>https://java.sun.com/products/jms/faq.html#msg_ack_close</url>
     </reference>
   </requirement>
 
@@ -919,7 +919,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#commit()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#commit()</url>
     </reference>
     <referenceId>section.7.3</referenceId>
   </requirement>
@@ -930,7 +930,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#rollback()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#rollback()</url>
     </reference>
   </requirement>
 
@@ -940,7 +940,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#recover()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#recover()</url>
     </reference>
   </requirement>
 
@@ -950,10 +950,10 @@
       <code>0</code>
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#getTimeToLive()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#getTimeToLive()</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#setTimeToLive()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#setTimeToLive()</url>
     </reference>
   </requirement>
 
@@ -969,19 +969,19 @@
       </p>
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Topic,%20javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Topic,%20javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Queue,%20javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Queue,%20javax.jms.Message)</url>
     </reference>
   </requirement>
 
@@ -1637,7 +1637,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[])</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[])</url>
     </reference>
   </requirement>
 
@@ -1646,7 +1646,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[], int)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[], int)</url>
     </reference>
   </requirement>
 
@@ -1655,7 +1655,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#writeObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#writeObject()</url>
     </reference>
   </requirement>
 
@@ -1664,7 +1664,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#setObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#setObject()</url>
     </reference>
   </requirement>
 
@@ -1673,7 +1673,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#itemExists()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#itemExists()</url>
     </reference>
   </requirement>
 
@@ -1682,7 +1682,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#getMapNames()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#getMapNames()</url>
     </reference>
   </requirement>
 
@@ -1701,7 +1701,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeObject()</url>
     </reference>
   </requirement>
 
@@ -1710,7 +1710,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[])</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[])</url>
     </reference>
   </requirement>
 
@@ -1719,7 +1719,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[], int, int)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[], int, int)</url>
     </reference>
   </requirement>
 
@@ -1728,7 +1728,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#readBytes</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#readBytes</url>
     </reference>
   </requirement>
 

--- a/src/main/resources/org/exolab/jmscts/provider/mapping.xml
+++ b/src/main/resources/org/exolab/jmscts/provider/mapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE mapping PUBLIC "-//EXOLAB/Castor Object Mapping DTD Version 1.0//EN"
-                         "http://castor.exolab.org/mapping.dtd">
+                         "https://castor.exolab.org/mapping.dtd">
 <mapping>
 
   <class name="org.exolab.jmscts.provider.Configuration">

--- a/src/main/resources/org/exolab/jmscts/requirements/requirements.xml
+++ b/src/main/resources/org/exolab/jmscts/requirements/requirements.xml
@@ -179,11 +179,11 @@
   </reference>
 
   <reference referenceId="url.message.bytes">
-    <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html</url>
+    <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html</url>
   </reference>
 
   <reference referenceId="url.message.stream">
-    <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html</url>
+    <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html</url>
   </reference>
 
   <requirement requirementId="selector.null">
@@ -899,7 +899,7 @@
       CLIENT_ACKWNOWLEDGE etc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/faq.html#msg_ack_close</url>
+      <url>https://java.sun.com/products/jms/faq.html#msg_ack_close</url>
     </reference>
   </requirement>
 
@@ -920,7 +920,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#commit()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#commit()</url>
     </reference>
     <referenceId>section.7.3</referenceId>
   </requirement>
@@ -931,7 +931,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#rollback()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#rollback()</url>
     </reference>
   </requirement>
 
@@ -941,7 +941,7 @@
       IllegalStateException
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#recover()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html#recover()</url>
     </reference>
   </requirement>
 
@@ -951,10 +951,10 @@
       <code>0</code>
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#getTimeToLive()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#getTimeToLive()</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#setTimeToLive()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html#setTimeToLive()</url>
     </reference>
   </requirement>
 
@@ -970,19 +970,19 @@
       </p>
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Topic,%20javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html#publish(javax.jms.Topic,%20javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Message)</url>
     </reference>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Queue,%20javax.jms.Message)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html#send(javax.jms.Queue,%20javax.jms.Message)</url>
     </reference>
   </requirement>
 
@@ -1638,7 +1638,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[])</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[])</url>
     </reference>
   </requirement>
 
@@ -1647,7 +1647,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[], int)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#readBytes(byte[], int)</url>
     </reference>
   </requirement>
 
@@ -1656,7 +1656,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#writeObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html#writeObject()</url>
     </reference>
   </requirement>
 
@@ -1665,7 +1665,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#setObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#setObject()</url>
     </reference>
   </requirement>
 
@@ -1674,7 +1674,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#itemExists()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#itemExists()</url>
     </reference>
   </requirement>
 
@@ -1683,7 +1683,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#getMapNames()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html#getMapNames()</url>
     </reference>
   </requirement>
 
@@ -1702,7 +1702,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeObject()</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeObject()</url>
     </reference>
   </requirement>
 
@@ -1711,7 +1711,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[])</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[])</url>
     </reference>
   </requirement>
 
@@ -1720,7 +1720,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[], int, int)</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#writeBytes(byte[], int, int)</url>
     </reference>
   </requirement>
 
@@ -1729,7 +1729,7 @@
       Refer to javadoc
     </description>
     <reference>
-      <url>http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#readBytes</url>
+      <url>https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html#readBytes</url>
     </reference>
   </requirement>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://castor.exolab.org/mapping.dtd (404) with 1 occurrences migrated to:  
  https://castor.exolab.org/mapping.dtd ([https](https://castor.exolab.org/mapping.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/products/jms/faq.html with 2 occurrences migrated to:  
  https://java.sun.com/products/jms/faq.html ([https](https://java.sun.com/products/jms/faq.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html with 8 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/BytesMessage.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html with 6 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/MapMessage.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html with 6 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/MessageProducer.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html with 4 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/QueueSender.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html with 6 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/Session.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html with 10 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/StreamMessage.html) result 302).
* http://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html with 4 occurrences migrated to:  
  https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html ([https](https://java.sun.com/products/jms/javadoc-102a/javax/jms/TopicPublisher.html) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences